### PR TITLE
Update NewClaimViewController+Uploading.swift

### DIFF
--- a/CodeysCarInsurance/NewClaimViewController+Uploading.swift
+++ b/CodeysCarInsurance/NewClaimViewController+Uploading.swift
@@ -81,7 +81,6 @@ extension NewClaimViewController {
 		var record = [String: Any]()
 		record["origin"] = "Codey's Car Insurance Mobile App"
 		record["status"] = "new"
-		record["accountId"] = accountID
 		record["subject"] = "Incident on \(dateFormatter.string(from: Date()))"
 		record["description"] = self.transcribedText
 		record["type"] = "Car Insurance"


### PR DESCRIPTION
René,

I've found including the accountId here can, at times, cause issue. Depending on whether or not the user created a brand new dev org, or setup the community in an existing dev org or sandbox. In the end, because this project utilizes communities, the account ID is automatically populated on the case by the community-users-contact and is therefore unneeded. This PR removes that one line.